### PR TITLE
Fix mouseup event

### DIFF
--- a/src/client/events/attrsToEvents.js
+++ b/src/client/events/attrsToEvents.js
@@ -3,7 +3,7 @@ export default {
     onMouseMove : 'mousemove',
     onMouseOut : 'mouseout',
     onMouseDown : 'mousedown',
-    onMouseUp : 'mousedown',
+    onMouseUp : 'mouseup',
     onClick : 'click',
     onDblClick : 'dblclick',
     onKeyDown : 'keydown',


### PR DESCRIPTION
Hi, i've found that `mousup`/`mousedown` events are not working properly. This happens because of typo in attrsToEvents table.