### PR TITLE
Mount uses firstElementChild instead of firstChild

### DIFF
--- a/spec/mountToDom/mountToDom.spec.js
+++ b/spec/mountToDom/mountToDom.spec.js
@@ -59,5 +59,10 @@ describe('mountToDom', () => {
                 done();
             });
         });
+
+        it('shouldn\'t try to mount a tree to non-element nodes', done => {
+            domNode.appendChild(document.createTextNode('test'));
+            mountToDom(domNode, createNode('div').children(createNode('span')), done);
+        });
     });
 });

--- a/spec/mountToDom/mountToDom.spec.js
+++ b/spec/mountToDom/mountToDom.spec.js
@@ -62,7 +62,18 @@ describe('mountToDom', () => {
 
         it('shouldn\'t try to mount a tree to non-element nodes', done => {
             domNode.appendChild(document.createTextNode('test'));
-            mountToDom(domNode, createNode('div').children(createNode('span')), done);
+            mountToDom(domNode, createNode('div'), () => {
+                expect(domNode.childNodes.length).to.equal(2);
+
+                // Ensure that the first node is our text node
+                expect(domNode.childNodes[0].nodeType).to.equal(Node.TEXT_NODE);
+                expect(domNode.childNodes[0].nodeValue).to.equal('test');
+
+                // Ensure that the second node is div from virtual tree
+                expect(domNode.childNodes[1].tagName.toLowerCase()).to.equal('div');
+
+                done();
+            });
         });
     });
 });

--- a/src/client/mounter.js
+++ b/src/client/mounter.js
@@ -23,7 +23,7 @@ function mount(domNode, tree, cb, cbCtx, syncMode) {
     else {
         mountedNodes[domNodeId] = { tree : null, id : mountId = ++counter };
 
-        let existingDom = domNode.firstChild;
+        let existingDom = domNode.firstElementChild;
         if(existingDom) {
             mountedNodes[domNodeId].tree = tree;
             tree.adoptDom(existingDom);


### PR DESCRIPTION
This fixes the case when an element we trying to mount components to
has a text node as the first child.